### PR TITLE
Fix memory leak

### DIFF
--- a/src/lib/crypt.cpp
+++ b/src/lib/crypt.cpp
@@ -166,18 +166,21 @@ QByteArray Crypt::encryptAES(QByteArray passphrase, QByteArray &data)
 	if(!EVP_EncryptInit_ex(&en, NULL, NULL, NULL, NULL))
 	{
 		qCritical() << "EVP_EncryptInit_ex() failed " <<  ERR_error_string(ERR_get_error(), NULL) ;
+		free(ciphertext);
 		return QByteArray();
 	}
 
 	if(!EVP_EncryptUpdate(&en, ciphertext, &c_len,(unsigned char *)input, len))
 	{
 		qCritical() << "EVP_EncryptUpdate() failed " <<  ERR_error_string(ERR_get_error(), NULL) ;
+		free(ciphertext);
 		return QByteArray();
 	}
 
 	if(!EVP_EncryptFinal(&en, ciphertext+c_len, &f_len))
 	{
 		qCritical() << "EVP_EncryptFinal_ex() failed " <<  ERR_error_string(ERR_get_error(), NULL) ;
+		free(ciphertext);
 		return QByteArray();
 	}
 


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio. Error:
IPConnect/src/lib/crypt.cpp	169	err V773 The function was exited without releasing the 'ciphertext' pointer. A memory leak is possible.