### PR TITLE
[WIP] Fixed possible nullptr expression

### DIFF
--- a/src/lib/crypt.cpp
+++ b/src/lib/crypt.cpp
@@ -160,8 +160,8 @@ QByteArray Crypt::encryptAES(QByteArray passphrase, QByteArray &data)
 	char *input = data.data();
 	int len = data.size();
 
-	int c_len = len + AES_BLOCK_SIZE, f_len = 0;
-	unsigned char *ciphertext = (unsigned char*)malloc(c_len);
+	int c_len = len, f_len = 0;
+	unsigned char *ciphertext = (unsigned char*)malloc(c_len + AES_BLOCK_SIZE);
 
 	if(!EVP_EncryptInit_ex(&en, NULL, NULL, NULL, NULL))
 	{


### PR DESCRIPTION
[Competition header]
The Pinguem.ru competition on finding errors in open source projects. Warnings, found using PVS-Studio:
IPConnect/src/lib/crypt.cpp	178	warn	V769 The 'ciphertext' pointer in the 'ciphertext + c_len' expression could be nullptr. In such case, resulting value will be senseless and it should not be used. Check lines: 178, 164.